### PR TITLE
Refine reproduction behavior and options

### DIFF
--- a/project/src/bugs/Bug.java
+++ b/project/src/bugs/Bug.java
@@ -1,7 +1,6 @@
 package bugs;
 
 import java.awt.Color;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -20,7 +19,7 @@ public abstract class Bug {
 
   private Vector2d position_;
   private final Color color_;
-  private boolean isReproducer_ = false;
+  private double reproductionScore_ = 0;
   private final Genome genome_;
   private final NeuralNet net_;
   private boolean isAlive_ = true;
@@ -40,7 +39,7 @@ public abstract class Bug {
   public Bug(Bug other) {
     position_ = new Vector2d(other.position_);
     color_ = new Color(other.color_.getRGB());
-    isReproducer_ = other.isReproducer_;
+    reproductionScore_ = other.reproductionScore_;
     genome_ = other.genome_;
     net_ = new NeuralNet(other.net_);
     isAlive_ = other.isAlive_;
@@ -104,12 +103,8 @@ public abstract class Bug {
     return color_;
   }
 
-  public void setIsReproducer(boolean isReproducer) {
-    isReproducer_ = isReproducer;
-  }
-
-  public boolean isReproducer() {
-    return isReproducer_;
+  public double getReproductionScore() {
+    return reproductionScore_;
   }
 
   public boolean isAlive() {
@@ -240,9 +235,12 @@ public abstract class Bug {
         });
   }
 
-  // Subclasses can override this if bugs "importance" is something other than
-  // just age
-  public static void sortBugs(List<Bug> bugList) {}
+  // Subclasses must override this to calculate a new reproduction score after all bugs have ticked
+  protected abstract double calculateReproductionScore(KDTree2d<BugType> bugTree, int round);
+
+  public void updateReproductionScore(KDTree2d<BugType> bugTree, int round) {
+    reproductionScore_ = calculateReproductionScore(bugTree, round);
+  }
 
   // Subclasses can override this if they need to do something at the beginning of
   // the tick

--- a/project/src/bugs/GameStates.java
+++ b/project/src/bugs/GameStates.java
@@ -4,27 +4,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import utils.OptionWithSchedulableChange;
 
 public class GameStates {
-  public static class GameStateHolder<T> {
-    private T value_;
-
+  public static class GameStateHolder<T> extends OptionWithSchedulableChange<T> {
     private GameStateHolder(T value) {
-      value_ = value;
+      super(value);
     }
 
-    private T getValue() {
-      return value_;
+    public void scheduleOptionChange(T newValue) {
+      scheduledChanges_.add(
+          new Runnable() {
+            @Override
+            public void run() {
+              setValue(newValue);
+            }
+          });
     }
-  }
-
-  public static <T> T findOptionInList(List<T> list, GameStateHolder<T> holder) {
-    for (T t : list) {
-      if (t.equals(holder.getValue())) {
-        return t;
-      }
-    }
-    return null;
   }
 
   // -- Traditional must move --
@@ -35,14 +31,15 @@ public class GameStates {
   }
 
   // -- Traditional reproduction rate --
-  public static final List<Integer> TRADITIONAL_REPRODUCTION_SECONDS_OPTIONS =
-      IntStream.rangeClosed(1, 60).boxed().collect(Collectors.toList());
-  public static GameStateHolder<Integer> TRADITIONAL_REPRODUCTION_SECONDS =
-      new GameStateHolder<>(20);
-
-  public static int getTraditionalReproductionSeconds() {
-    return TRADITIONAL_REPRODUCTION_SECONDS.getValue();
-  }
+  // TODO: Bring back once sheep reproduction behavior is refined
+  //  public static final List<Integer> TRADITIONAL_REPRODUCTION_SECONDS_OPTIONS =
+  //      IntStream.rangeClosed(1, 60).boxed().collect(Collectors.toList());
+  //  public static GameStateHolder<Integer> TRADITIONAL_REPRODUCTION_SECONDS =
+  //      new GameStateHolder<>(20);
+  //
+  //  public static int getTraditionalReproductionSeconds() {
+  //    return TRADITIONAL_REPRODUCTION_SECONDS.getValue();
+  //  }
 
   // -- Killers exist --
   public static GameStateHolder<Boolean> KILLERS_EXIST = new GameStateHolder<>(true);
@@ -90,16 +87,6 @@ public class GameStates {
   public static void initialize() {
     scheduledChanges_ = new ArrayList<>();
     scheduledReset_ = false;
-  }
-
-  public static <T> void scheduleChange(GameStateHolder<T> holder, T newValue) {
-    scheduledChanges_.add(
-        new Runnable() {
-          @Override
-          public void run() {
-            holder.value_ = newValue;
-          }
-        });
   }
 
   public static void runScheduledChanges() {

--- a/project/src/bugs/KillerBug.java
+++ b/project/src/bugs/KillerBug.java
@@ -1,5 +1,6 @@
 package bugs;
 
+import utils.KDTree2d;
 import utils.Vector2d;
 
 public class KillerBug extends Bug {
@@ -50,6 +51,13 @@ public class KillerBug extends Bug {
   protected void onTickStart() {
     killedThisRound_ = false;
     sinceLastKill_++;
+  }
+
+  @Override
+  protected double calculateReproductionScore(KDTree2d<BugType> bugTree, int round) {
+    // Once bug reaches GameStates.getKillerNKillsToReproduce() kills, it should have a reproduction
+    // score of `1`, so that it is allowed to reproduce
+    return numKillsSinceLastReproduction_ - (GameStates.getKillerNKillsToReproduce() - 1);
   }
 
   @Override

--- a/project/src/bugs/TraditionalBug.java
+++ b/project/src/bugs/TraditionalBug.java
@@ -1,8 +1,13 @@
 package bugs;
 
+import utils.KDTree2d;
 import utils.Vector2d;
 
 public class TraditionalBug extends Bug {
+  // TODO: Should be a game state (and should also have a dropdown to control distance vs time or
+  // whatever)
+  private static final double DISTANCE_NEEDED_TO_REPRODUCE = 25.;
+
   private final int birthRound_;
   private int slowRounds = 0;
 
@@ -31,17 +36,30 @@ public class TraditionalBug extends Bug {
     return birthRound_;
   }
 
-  public boolean isOldEnoughToReproduct(int currRound) {
-    // In addition to all the bugs that are actually old enough to reproduce,
-    // consider all bugs born at the beginning of the game
-    // "old enough to reproduce"
-    int minReproductionAge = 60 /* ~ fps */ * GameStates.getTraditionalReproductionSeconds();
-    return (currRound - birthRound_ > minReproductionAge) || birthRound_ < minReproductionAge;
-  }
+  //  public boolean isOldEnoughToReproduce(int currRound) {
+  //    if (getNeuralNet().getResultLayer()[2] < 0.95) {
+  //      return false;
+  //    }
+  //
+  //    // In addition to all the bugs that are actually old enough to reproduce,
+  //    // consider all bugs born at the beginning of the game
+  //    // "old enough to reproduce"
+  //    int minReproductionAge = 60 /* ~ fps */ * GameStates.getTraditionalReproductionSeconds();
+  //    return (currRound - birthRound_ > minReproductionAge) || birthRound_ < minReproductionAge;
+  //  }
 
   @Override
   public BugType getBugType() {
     return BugType.TRADITIONAL;
+  }
+
+  @Override
+  protected double calculateReproductionScore(KDTree2d<BugType> bugTree, int round) {
+    Vector2d nearest = bugTree.findNearestExcludingSame(getPosition()).getLocation();
+    double centerDistance = getPosition().subtract(nearest).norm();
+    double gap = centerDistance - 2 * GameStates.getBugRadius();
+    // Must have at least DISTANCE_NEEDED_TO_REPRODUCE gap in order to reproduce
+    return gap - DISTANCE_NEEDED_TO_REPRODUCE;
   }
 
   @Override

--- a/project/src/display/AdjustmentsPanel.java
+++ b/project/src/display/AdjustmentsPanel.java
@@ -1,13 +1,9 @@
 package display;
 
-import bugs.GameStates;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.ItemSelectable;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -17,9 +13,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
 import javax.swing.JTextField;
-import javax.swing.SpinnerListModel;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
+import bugs.GameStates;
+import utils.OptionWithSchedulableChange;
 
 public class AdjustmentsPanel extends JPanel {
   private static final long serialVersionUID = 1L;
@@ -27,18 +22,25 @@ public class AdjustmentsPanel extends JPanel {
   public AdjustmentsPanel() {
     this.setLayout(new GridBagLayout());
 
-    int col = -1;
+    int row = -1;
+
+    // -- Show matings --
+    JCheckBox showMatings =
+        ComponentTiedToOption.checkBoxTiedToBoolean("Show matings", DisplayOptions.SHOW_MATINGS);
+    addToGrid(showMatings, 0, ++row, 2);
 
     // -- Wolves exist --
-    JCheckBox wolvesExist = new JCheckBox("Wolves exist", GameStates.getKillersExist());
-    tieToBoolean(wolvesExist, GameStates.KILLERS_EXIST);
-    addToGrid(wolvesExist, 0, ++col, 2);
+    JCheckBox wolvesExist =
+        ComponentTiedToOption.checkBoxTiedToBoolean("Wolves exist", GameStates.KILLERS_EXIST);
+    addToGrid(wolvesExist, 0, ++row, 2);
+
+    addToGrid(showMatings, 0, ++row, 2);
 
     // -- Sheep must move --
     JCheckBox sheepMustMove =
-        new JCheckBox("Sheep must move to survive", GameStates.getTraditionalMustMove());
-    tieToBoolean(sheepMustMove, GameStates.TRADITIONAL_MUST_MOVE);
-    addToGrid(sheepMustMove, 0, ++col, 2);
+        ComponentTiedToOption.checkBoxTiedToBoolean(
+            "Sheep must move to survive", GameStates.KILLERS_EXIST);
+    addToGrid(sheepMustMove, 0, ++row, 2);
 
     // -- Wolf starvation --
     JPanel wolfStarvationPanel = new JPanel();
@@ -52,23 +54,24 @@ public class AdjustmentsPanel extends JPanel {
 
     JLabel wolfStarvationLabel2 = new JLabel("seconds");
     wolfStarvationPanel.add(wolfStarvationLabel2);
-    addToGrid(wolfStarvationPanel, 0, ++col, 2);
+    addToGrid(wolfStarvationPanel, 0, ++row, 2);
 
     // -- Sheep reproduction rate --
-    JPanel sheepReproductionPanel = new JPanel();
-    JLabel sheepReproductionLabel1 = new JLabel("Sheep reproduce after");
-    sheepReproductionPanel.add(sheepReproductionLabel1);
-
-    JSpinner sheepReproductionSpinner =
-        makeIntegerSpinner(
-            GameStates.TRADITIONAL_REPRODUCTION_SECONDS,
-            GameStates.TRADITIONAL_REPRODUCTION_SECONDS_OPTIONS,
-            2);
-    sheepReproductionPanel.add(sheepReproductionSpinner);
-
-    JLabel sheepReproductionLabel2 = new JLabel("seconds");
-    sheepReproductionPanel.add(sheepReproductionLabel2);
-    addToGrid(sheepReproductionPanel, 0, ++col, 2);
+    // TODO: Bring back once sheep reproduction behavior is refined
+    //    JPanel sheepReproductionPanel = new JPanel();
+    //    JLabel sheepReproductionLabel1 = new JLabel("Sheep reproduce after");
+    //    sheepReproductionPanel.add(sheepReproductionLabel1);
+    //
+    //    JSpinner sheepReproductionSpinner =
+    //        makeIntegerSpinner(
+    //            GameStates.TRADITIONAL_REPRODUCTION_SECONDS,
+    //            GameStates.TRADITIONAL_REPRODUCTION_SECONDS_OPTIONS,
+    //            2);
+    //    sheepReproductionPanel.add(sheepReproductionSpinner);
+    //
+    //    JLabel sheepReproductionLabel2 = new JLabel("seconds");
+    //    sheepReproductionPanel.add(sheepReproductionLabel2);
+    //    addToGrid(sheepReproductionPanel, 0, ++row, 2);
 
     // -- Wolf reproduction --
     JPanel wolfReproductionPanel = new JPanel();
@@ -84,7 +87,7 @@ public class AdjustmentsPanel extends JPanel {
 
     JLabel wolfReproductionLabel2 = new JLabel("sheep to reproduce");
     wolfReproductionPanel.add(wolfReproductionLabel2);
-    addToGrid(wolfReproductionPanel, 0, ++col, 2);
+    addToGrid(wolfReproductionPanel, 0, ++row, 2);
 
     // -- Bug radius --
     JPanel bugRadiusPanel = new JPanel();
@@ -94,7 +97,7 @@ public class AdjustmentsPanel extends JPanel {
     JSpinner bugRadiusSpinner =
         makeIntegerSpinner(GameStates.BUG_RADIUS, GameStates.BUG_RADIUS_OPTIONS, 2);
     bugRadiusPanel.add(bugRadiusSpinner);
-    addToGrid(bugRadiusPanel, 0, ++col, 1);
+    addToGrid(bugRadiusPanel, 0, ++row, 1);
 
     // -- Reset Button
     JButton resetButton = new JButton("Reset");
@@ -108,44 +111,20 @@ public class AdjustmentsPanel extends JPanel {
         });
     GridBagConstraints resetConstraints = new GridBagConstraints();
     resetConstraints.gridx = 1;
-    resetConstraints.gridy = col;
+    resetConstraints.gridy = row;
     resetConstraints.gridwidth = 1;
     resetConstraints.anchor = GridBagConstraints.EAST;
     this.add(resetButton, resetConstraints);
   }
 
   private JSpinner makeIntegerSpinner(
-      GameStates.GameStateHolder<Integer> integerHolder, List<Integer> options, int nColumns) {
-    JSpinner intSpinner = new JSpinner(new SpinnerListModel(options));
-    intSpinner.setValue(GameStates.findOptionInList(options, integerHolder));
-    tieToInteger(intSpinner, integerHolder);
+      OptionWithSchedulableChange<Integer> integerOption, List<Integer> options, int nColumns) {
+    JSpinner intSpinner = ComponentTiedToOption.spinnerTiedToIntegers(integerOption, options);
     JFormattedTextField intField = ((JSpinner.DefaultEditor) intSpinner.getEditor()).getTextField();
     intField.setColumns(nColumns);
     intField.setHorizontalAlignment(JTextField.RIGHT);
     intField.setEditable(false);
     return intSpinner;
-  }
-
-  private void tieToBoolean(
-      ItemSelectable selectable, GameStates.GameStateHolder<Boolean> booleanHolder) {
-    selectable.addItemListener(
-        new ItemListener() {
-          @Override
-          public void itemStateChanged(ItemEvent e) {
-            GameStates.scheduleChange(
-                booleanHolder, e.getStateChange() == ItemEvent.SELECTED ? true : false);
-          }
-        });
-  }
-
-  private void tieToInteger(JSpinner spinner, GameStates.GameStateHolder<Integer> integerHolder) {
-    spinner.addChangeListener(
-        new ChangeListener() {
-          @Override
-          public void stateChanged(ChangeEvent e) {
-            GameStates.scheduleChange(integerHolder, (Integer) spinner.getValue());
-          }
-        });
   }
 
   private void addToGrid(JComponent component, int gridx, int gridy, int gridwidth) {

--- a/project/src/display/ComponentTiedToOption.java
+++ b/project/src/display/ComponentTiedToOption.java
@@ -1,0 +1,45 @@
+package display;
+
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.util.List;
+import javax.swing.JCheckBox;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerListModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import utils.OptionWithSchedulableChange;
+
+public abstract class ComponentTiedToOption {
+  public static JCheckBox checkBoxTiedToBoolean(
+      String label, OptionWithSchedulableChange<Boolean> booleanOption) {
+    JCheckBox checkBox = new JCheckBox(label, booleanOption.getValue());
+
+    checkBox.addItemListener(
+        new ItemListener() {
+          @Override
+          public void itemStateChanged(ItemEvent e) {
+            booleanOption.scheduleOptionChange(
+                e.getStateChange() == ItemEvent.SELECTED ? true : false);
+          }
+        });
+
+    return checkBox;
+  }
+
+  public static JSpinner spinnerTiedToIntegers(
+      OptionWithSchedulableChange<Integer> integerOption, List<Integer> options) {
+    JSpinner intSpinner = new JSpinner(new SpinnerListModel(options));
+    intSpinner.setValue(integerOption.getValue());
+
+    intSpinner.addChangeListener(
+        new ChangeListener() {
+          @Override
+          public void stateChanged(ChangeEvent e) {
+            integerOption.scheduleOptionChange((Integer) intSpinner.getValue());
+          }
+        });
+
+    return intSpinner;
+  }
+}

--- a/project/src/display/DisplayOptions.java
+++ b/project/src/display/DisplayOptions.java
@@ -1,0 +1,31 @@
+package display;
+
+import utils.OptionWithSchedulableChange;
+
+public class DisplayOptions {
+  public static class DisplayOption<T> extends OptionWithSchedulableChange<T> {
+    public DisplayOption(T value) {
+      super(value);
+    }
+
+    // At some point there may be a need to schedule DisplayOptions between draw calls, but for now
+    // the changes are just applied immediately
+    public void scheduleOptionChange(T newValue) {
+      setValue(newValue);
+    }
+  }
+
+  // -- Show matings --
+  public static DisplayOption<Boolean> SHOW_BIASES = new DisplayOption<>(false);
+
+  public static boolean shouldShowBiases() {
+    return SHOW_BIASES.getValue();
+  }
+
+  // -- Show matings --
+  public static DisplayOption<Boolean> SHOW_MATINGS = new DisplayOption<>(false);
+
+  public static boolean shouldShowMatings() {
+    return SHOW_MATINGS.getValue();
+  }
+}

--- a/project/src/display/MainDrawPanel.java
+++ b/project/src/display/MainDrawPanel.java
@@ -1,8 +1,5 @@
 package display;
 
-import bugs.Bug;
-import bugs.BugType;
-import bugs.GameStates;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -10,31 +7,74 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.swing.JPanel;
+import bugs.Bug;
+import bugs.BugController.TickCompletedMessage;
+import bugs.BugType;
+import bugs.GameStates;
+import utils.Pair;
 import utils.Sizes;
 import utils.Vector2d;
 
 public class MainDrawPanel extends JPanel {
   private static final long serialVersionUID = 0;
-  private List<Bug> currBugList_;
-  private List<Bug> nextBugList_;
+  private TickCompletedMessage nextMessage_;
   private long currMillis_;
   private double rollingFPS_ = 60.0;
+  // TODO: Allow picking of which bug's net is shown using the mouse
+  //  private Point mousePosition_ = null;
 
   private static final NumberFormat FORMATTER = new DecimalFormat("#0.0");
 
   public MainDrawPanel() {
     currMillis_ = System.currentTimeMillis();
+    //    MouseHandler mouseHandler = new MouseHandler();
+    //    addMouseMotionListener(mouseHandler);
   }
 
-  public void repaint(List<Bug> bugList) {
-    nextBugList_ = bugList;
+  //  private class MouseHandler implements MouseListener, MouseMotionListener {
+  //    // -- MouseListener --
+  //    @Override
+  //    public void mouseClicked(MouseEvent e) {}
+  //
+  //    @Override
+  //    public void mousePressed(MouseEvent e) {}
+  //
+  //    @Override
+  //    public void mouseReleased(MouseEvent e) {}
+  //
+  //    @Override
+  //    public void mouseEntered(MouseEvent e) {}
+  //
+  //    @Override
+  //    public void mouseExited(MouseEvent e) {
+  //      mousePosition_ = null;
+  //    }
+  //
+  //    // -- MouseMotionListener --
+  //
+  //    @Override
+  //    public void mouseDragged(MouseEvent e) {}
+  //
+  //    @Override
+  //    public void mouseMoved(MouseEvent e) {
+  //      mousePosition_ = e.getPoint();
+  //    }
+  //  }
+
+  public void repaint(TickCompletedMessage message) {
+    // In case a repaint is currently happening, do not overwrite the state it is currently using
+    nextMessage_ = message;
     super.repaint();
   }
 
   @Override
   public void paintComponent(Graphics g) {
+    TickCompletedMessage currMessage = nextMessage_;
+    
     long millis = System.currentTimeMillis();
     long elapsed = millis - currMillis_;
     currMillis_ = millis;
@@ -58,20 +98,58 @@ public class MainDrawPanel extends JPanel {
     graphics.fillRect(
         border, border, (int) (boardSize.getX() * scale), (int) (boardSize.getY() * scale));
 
-    currBugList_ = nextBugList_;
-    if (currBugList_ == null) {
-      return;
+    int traditionalCount = 0;
+    int killerCount = 0;
+    if (currMessage != null) {
+      drawBugs(graphics, currMessage.bugList, scale);
+      drawMatings(graphics, currMessage.matings, scale);
+
+      if (currMessage.bugList != null) {
+        for (Bug bug : currMessage.bugList) {
+          if (bug.getBugType() == BugType.TRADITIONAL) {
+            traditionalCount += 1;
+          }
+          if (bug.getBugType() == BugType.KILLER) {
+            killerCount += 1;
+          }
+        }
+      }
     }
 
-    int killerCount = 0;
-    for (Bug bug : currBugList_) {
-      boolean isKiller = bug.getBugType() == BugType.KILLER;
-      if (bug.isReproducer()) {
-        Color ringColor =
-            (bug == currBugList_.get(0) || (isKiller && killerCount == 0))
-                ? Color.WHITE
-                : Color.RED;
-        graphics.setColor(ringColor);
+    graphics.setColor(Color.WHITE);
+    double fps = 1000.0 / (Math.max(1, elapsed));
+    rollingFPS_ = (0.999 * rollingFPS_) + 0.001 * (fps);
+    graphics.drawString("FPS: " + FORMATTER.format(rollingFPS_), 5 + border, 15 + border);
+    graphics.drawString("Sheep: " + traditionalCount, 70 + border, 15 + border);
+    graphics.drawString("Wolves: " + killerCount, 150 + border, 15 + border);
+  }
+  
+  private static void drawBugs(Graphics2D graphics, List<Bug> bugList, double scale) {
+    if (bugList == null) {
+      return;
+    }
+    
+    Map<BugType, Double> maxReproductionScorePerBugType = new HashMap<>();
+    for (Bug bug : bugList) {
+      maxReproductionScorePerBugType.compute(
+          bug.getBugType(),
+          (k, v) ->
+              v == null ? bug.getReproductionScore() : Math.max(v, bug.getReproductionScore()));
+    }
+
+    for (Bug bug : bugList) {
+      // Draw a ring around reproducers
+      double reproductionScore = bug.getReproductionScore();
+      if (reproductionScore > 0.) {
+        float ringPercent =
+            (float) (reproductionScore / maxReproductionScorePerBugType.get(bug.getBugType()));
+        // 0% -> RED (1, 0, 0), 50% -> YELLOW (1, 1, 0), 100% GREEN (0, 1, 0)
+        // red is 1 from 0% -> 50%, then 1 -> 0 from 50% -> 100%
+        float ringRed = Math.min(1.f, 2.f * (1.f - ringPercent));
+        // green is 0 -> 1 from 0% -> 50%, then 1 from 50% -> 100%
+        float ringGreen = Math.min(1.f, 2.f * ringPercent);
+        graphics.setColor(new Color(ringRed, ringGreen, 0.f));
+
         drawBug(graphics, bug, scale, GameStates.getBugRadius() + 3.0);
         graphics.setColor(Color.BLACK);
         drawBug(graphics, bug, scale, GameStates.getBugRadius() + 2.0);
@@ -80,19 +158,11 @@ public class MainDrawPanel extends JPanel {
       graphics.setColor(bug.getColor());
       drawBug(graphics, bug, scale, GameStates.getBugRadius());
 
-      if (isKiller) {
+      if (bug.getBugType() == BugType.KILLER) {
         graphics.setColor(Color.BLACK);
         drawBug(graphics, bug, scale, GameStates.getBugRadius() - 2.0);
-        killerCount++;
       }
     }
-
-    graphics.setColor(Color.WHITE);
-    double fps = 1000.0 / (Math.max(1, elapsed));
-    rollingFPS_ = (0.999 * rollingFPS_) + 0.001 * (fps);
-    graphics.drawString("FPS: " + FORMATTER.format(rollingFPS_), 5 + border, 15 + border);
-    graphics.drawString("Sheep: " + (currBugList_.size() - killerCount), 70 + border, 15 + border);
-    graphics.drawString("Wolves: " + killerCount, 150 + border, 15 + border);
   }
 
   private static void drawBug(Graphics2D graphics, Bug bug, double scale, double size) {
@@ -102,5 +172,20 @@ public class MainDrawPanel extends JPanel {
         (int) ((bug.getPosition().getY() - size) * scale) + border,
         (int) (size * 2.0 * scale),
         (int) (size * 2.0 * scale));
+  }
+
+  private static void drawMatings(Graphics2D graphics, List<Pair<Bug, Bug>> matings, double scale) {
+    if (matings == null || !DisplayOptions.shouldShowMatings()) {
+      return;
+    }
+
+    graphics.setColor(Color.YELLOW);
+    for (Pair<Bug, Bug> mating : matings) {
+      graphics.drawLine(
+          (int) (mating.first.getPosition().getX() * scale),
+          (int) (mating.first.getPosition().getY() * scale),
+          (int) (mating.second.getPosition().getX() * scale),
+          (int) (mating.second.getPosition().getY() * scale));
+    }
   }
 }

--- a/project/src/display/NetDrawPanel.java
+++ b/project/src/display/NetDrawPanel.java
@@ -1,6 +1,5 @@
 package display;
 
-import bugs.NeuralNet;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -8,8 +7,8 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import javax.swing.JCheckBox;
 import javax.swing.JPanel;
+import bugs.NeuralNet;
 import utils.Vector2d;
 
 public class NetDrawPanel extends JPanel {
@@ -22,12 +21,6 @@ public class NetDrawPanel extends JPanel {
 
   private NeuralNet currSelectedBugNet_;
   private NeuralNet nextSelectedBugNet_;
-
-  private final JCheckBox showBiases_;
-
-  public NetDrawPanel(JCheckBox showBiases) {
-    showBiases_ = showBiases;
-  }
 
   public void repaint(NeuralNet selectedBugNet) {
     nextSelectedBugNet_ = selectedBugNet;
@@ -105,7 +98,7 @@ public class NetDrawPanel extends JPanel {
           double edgeValue =
               (nodeValues[layer][startNode]
                   * currSelectedBugNet_.getWeightAt(layer, startNode, endNode));
-          if (showBiases_.isSelected()) {
+          if (DisplayOptions.shouldShowBiases()) {
             edgeValue += currSelectedBugNet_.getBiasAt(layer + 1, endNode);
             edgeValue /= 2.5;
           }

--- a/project/src/utils/OptionWithSchedulableChange.java
+++ b/project/src/utils/OptionWithSchedulableChange.java
@@ -1,0 +1,19 @@
+package utils;
+
+public abstract class OptionWithSchedulableChange<T> {
+  private T value_;
+
+  protected OptionWithSchedulableChange(T value) {
+    value_ = value;
+  }
+
+  public T getValue() {
+    return value_;
+  }
+
+  protected void setValue(T newValue) {
+    value_ = newValue;
+  }
+
+  public abstract void scheduleOptionChange(T newValue);
+}

--- a/project/src/utils/Pair.java
+++ b/project/src/utils/Pair.java
@@ -1,0 +1,11 @@
+package utils;
+
+public class  Pair<T, U> {
+  public final T first;
+  public final U second;
+
+  public Pair(T first, U second) {
+    this.first = first;
+    this.second = second;
+  }
+}


### PR DESCRIPTION
- Generalized reproduction behavior across bug types to use a "reproduction score"
- Updated graphics so that reproduction score determines ring color around bugs
- Updated tick completion producer to provide mating information to display system
- Created new option to display matings (as lines flashed on the screen)
- Genericized a "option with scheduled change" so that options panels can interact with an interface, rather than specifically the GameStates
- Created a new type of option called "display option" which is less strict about scheduling, and moved "show biases" to be this type of option
- Created generic code for tying components to options